### PR TITLE
saved token and logout redirect back to app url

### DIFF
--- a/Security/Firewall/CasListener.php
+++ b/Security/Firewall/CasListener.php
@@ -69,9 +69,9 @@ class CasListener extends AbstractAuthenticationListener
             \phpCAS::setNoCasServerValidation();
 	}
         \phpCAS::forceAuthentication();
-        if($this->options['cas_mapping_attribute']) {
-            $attributes = \phpCAS::getAttributes();
+        $attributes = \phpCAS::getAttributes();
 
+        if($this->options['cas_mapping_attribute']) {
             if (!$attributes[$this->options['cas_mapping_attribute']]) {
                 return;
             }
@@ -86,6 +86,9 @@ class CasListener extends AbstractAuthenticationListener
             $this->logger->info(sprintf('Authentication success: %s', $user));
         }
 
-        return $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials, $this->providerKey));
+        $newToken = new PreAuthenticatedToken($user, $credentials, %this->providerKey);
+        $newToken->setAttributes($attributes);
+
+        return $this->authenticationManager->authenticate($newToken);
     }
 }

--- a/Security/Handler/LogoutSuccessHandler.php
+++ b/Security/Handler/LogoutSuccessHandler.php
@@ -37,7 +37,7 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
 
         \phpCAS::client($this->options['cas_protocol'], $this->options['cas_server'], $this->options['cas_port'], $this->options['cas_path'], false);   
 
-        \phpCAS::logout();
+        \phpCAS::logoutWithRedirectService($request->getScheme().'://'.$request->getHttpHost());
         return null;
     }
 }


### PR DESCRIPTION
- in CasListener.php, I moved the getting attribute call outside the if statement so that the else won't throw an error
- in LogoutSuccessHandler.php, I made the logout redirect back to applicaiton url root.  Might need a smarter way of doing things.
