### PR TITLE
Add support for logout service parameter

### DIFF
--- a/DependencyInjection/Security/Factory/CasFactory.php
+++ b/DependencyInjection/Security/Factory/CasFactory.php
@@ -79,6 +79,7 @@ class CasFactory extends AbstractFactory
         $this->addOption('ca_cert_path', '');
         $this->addOption('cas_protocol', 'S1');
         $this->addOption('cas_mapping_attribute', '###CAS_USER_NAME###');
+        $this->addOption('cas_logout', '');
     }
 
     /**
@@ -91,15 +92,16 @@ class CasFactory extends AbstractFactory
 	/* Load the configuration */
         $node
             ->children()
-		->scalarNode('cas_server')->end()
-		->variableNode('cas_port')->end()
-		->scalarNode('cas_path')->end()
-		->scalarNode('ca_cert_path')->end()
-		->scalarNode('cas_protocol')->defaultValue('S1')->end() /* S1 for SAML_VERSION_1, 1.0 for CAS 1, 2.0 for CAS 2.0, See CAS.php for more information */
-		->scalarNode('cas_mapping_attribute')->defaultValue("###CAS_USER_NAME###")->end() /* default value reprensent the username returned by cas (not an attribute) */
+                ->scalarNode('cas_server')->end()
+                ->variableNode('cas_port')->end()
+                ->scalarNode('cas_path')->end()
+                ->scalarNode('ca_cert_path')->end()
+                ->scalarNode('cas_protocol')->defaultValue('S1')->end() /* S1 for SAML_VERSION_1, 1.0 for CAS 1, 2.0 for CAS 2.0, See CAS.php for more information */
+                ->scalarNode('cas_mapping_attribute')->defaultValue("###CAS_USER_NAME###")->end() /* default value reprensent the username returned by cas (not an attribute) */
                 ->scalarNode('check_path')->end()
-		->end()
-			;
+                ->scalarNode('cas_logout')->end()
+		    ->end()
+        ;
     }
 
     protected function getListenerId()
@@ -148,7 +150,7 @@ class CasFactory extends AbstractFactory
         // dont know if this is the right way, but it works
         $container
             ->setDefinition($realHandler, new DefinitionDecorator($templateHandler))
-            ->addArgument($config)
+            ->replaceArgument(0, $config)
         ;
     }
 }

--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ Please edit app/config/security.yml file to update symfony security policy
                         ca_cert_path: ~
                         cas_protocol: S1
                         cas_mapping_attribute: username
+                        cas_logout: /logout
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,6 +18,8 @@
         </service>
 
         <service id="cas.security.handler.logout" class="%auth_cas_logout_handler.class%">
+            <argument type="collection" />
+            <argument type="service" id="router" />
         </service>
 
         <service id="cas.security.authentication.cas_entry_point" class="%auth_cas_entry_point.class%" public="false" abstract="true">

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "jasig/phpcas": "~1.3"
+        "jasig/phpcas": "~1.3",
+        "symfony/http-foundation": "~2.1",
+        "symfony/security": "~2.1",
+        "symfony/routing": "~2.1"
     },
     "autoload": {
         "psr-0": { "Gorg\\Bundle\\CasBundle": "" }


### PR DESCRIPTION
As per cas protocol (https://github.com/Jasig/cas/blob/master/cas-server-protocol/3.0/cas_protocol_3_0.md#231-parameters), an optional service parameter can be specified to redirect user after logging out. This commit adding support for service parameter and added missing dependencies in composer.json
