### PR TITLE
Force jasig/phpcas with version 1.3.2 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "jasig/phpcas": "~1.3",
+        "jasig/phpcas": "^1.3.2",
         "symfony/http-foundation": "~2.1",
         "symfony/security": "~2.1",
         "symfony/routing": "~2.1"


### PR DESCRIPTION
> All phpCAS versions before 1.3.2 have multiple security issues: CVE-2012-5583, CVE-2010-2795, CVE-2010-2796,CVE-2010-3690,CVE-2010-3691,CVE-2010-3692, CVE-2012-1104, CVE-2012-1105.

Ref: https://wiki.jasig.org/display/CASC/phpCAS

This PR forces you to use 1.3.2 or higher. I used the [Caret Operator](https://getcomposer.org/doc/01-basic-usage.md#package-versions) to make sure the versions is `>=1.3.2` and `< 2.0`.
